### PR TITLE
Bump log4j.version from 2.17.1 to 2.19.0

### DIFF
--- a/src/de/bielefeld/umweltamt/aui/utils/AuikLoggerFactory.java
+++ b/src/de/bielefeld/umweltamt/aui/utils/AuikLoggerFactory.java
@@ -23,12 +23,8 @@ package de.bielefeld.umweltamt.aui.utils;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.apache.log4j.PatternLayout;
-import org.apache.log4j.PropertyConfigurator;
 import org.apache.log4j.spi.LoggerFactory;
 import org.apache.logging.log4j.core.LoggerContext;
-
-import de.bielefeld.umweltamt.aui.AUIKataster;
 
 /**
  * AuikLogger factory which sets different logging levels for different users.
@@ -42,12 +38,12 @@ public class AuikLoggerFactory implements LoggerFactory {
 
 	/**
 	 * Must be implemented for using log4j compatibility API
-	 * @return The new AuikLogger instance 
+	 * @return The new AuikLogger instance
 	 */
 	public Logger makeNewLoggerInstance(LoggerContext context, String name){
 		if (AuikLoggerFactory.needsToRunInit) init();
 		return new AuikLogger(name);
-	
+
 	}
 	/**
 	 * Make sure we run {@link AuikLoggerFactory.init} and
@@ -63,8 +59,6 @@ public class AuikLoggerFactory implements LoggerFactory {
 
 	/** Initialize the Logger with user specific log levels */
 	private static void init() {
-	    PropertyConfigurator.configure(
-			AUIKataster.class.getResource("resources/config/log4j2.xml"));
 		AuikLoggerFactory.setSpecialLogLevelsByUser();
 		// If we want to do some global formatting, it would go here.
 		needsToRunInit = false;


### PR DESCRIPTION
Hallo Alex, 

ich habe den Pull Request erneut gestellt, weil beim testen habe ich festgestellt, dass ich dann in der Console nichts mehr sehe. Und so eine Fehleranalyse schwer wird. Das müsste wir uns dann nochmal anschauen.

LG
Lisa


Bumps `log4j.version` from 2.17.1 to 2.19.0.

Updates `log4j-1.2-api` from 2.17.1 to 2.19.0

Updates `log4j-api` from 2.17.1 to 2.19.0

Updates `log4j-core` from 2.17.1 to 2.19.0

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-1.2-api dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.logging.log4j:log4j-api dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.logging.log4j:log4j-core dependency-type: direct:production update-type: version-update:semver-minor ...

Signed-off-by: dependabot[bot] <support@github.com>