### PR TITLE
Bump hibernate-search-engine from 5.4.0.Final to 5.11.9.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,8 @@
     <jersey.version>2.5</jersey.version>
     <jasper.version>6.13.0</jasper.version>
     <log4j.version>2.17.1</log4j.version>
+    <hibernate-search.version>5.11.9.Final</hibernate-search.version>
+    <lucene.version>5.5.5</lucene.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <dependencies>
@@ -15,7 +17,7 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-tools</artifactId>
-      <version>5.0.0.Final</version>
+      <version>5.4.33.Final</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -244,7 +246,7 @@
     </dependency>
 
     <!-- A repacked jasperreports jar file with necessary fonts included, workaround for font problems on Windows systems-->
-    <!-- 
+    <!--
     <dependency>
         <groupId>de.bielefeld.umweltamt.aui</groupId>
         <artifactId>jasperreports-auik-font-repack</artifactId>
@@ -265,12 +267,12 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-search-engine</artifactId>
-      <version>5.11.9.Final</version>
+      <version>${hibernate-search.version}</version>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-search-orm</artifactId>
-      <version>5.4.0.Final</version>
+      <version>${hibernate-search.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.hk2</groupId>
@@ -355,12 +357,12 @@
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-analyzers-common</artifactId>
-      <version>4.10.4</version>
+      <version>${lucene.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>
-      <version>4.10.4</version>
+      <version>${lucene.version}</version>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>


### PR DESCRIPTION
Hier gibt es ein Problem mit den Dependencies, kann das Programm nicht starten. Die Fehlermeldung habe ich angehängt

Bumps [hibernate-search-engine](https://github.com/hibernate/hibernate-search) from 5.4.0.Final to 5.11.9.Final.
- [Release notes](https://github.com/hibernate/hibernate-search/releases)
- [Changelog](https://github.com/hibernate/hibernate-search/blob/5.11.9.Final/changelog.txt)
- [Commits](https://github.com/hibernate/hibernate-search/compare/5.4.0.Final...5.11.9.Final)

---
updated-dependencies:
- dependency-name: org.hibernate:hibernate-search-engine dependency-type: direct:production update-type: version-update:semver-minor ...
[Fehlermedlunghibernate-search-engine_5.11.9.txt](https://github.com/stadt-bielefeld/auik/files/9774973/Fehlermedlunghibernate-search-engine_5.11.9.txt)

Signed-off-by: dependabot[bot] <support@github.com>

[Fehlermedlunghibernate-search-engine_5.11.9.txt](https://github.com/stadt-bielefeld/auik/files/9774973/Fehlermedlunghibernate-search-engine_5.11.9.txt)