### PR TITLE
Sielhautsteckbriefe Drucken

### DIFF
--- a/src/de/bielefeld/umweltamt/aui/mappings/DatabaseAtlQuery.java
+++ b/src/de/bielefeld/umweltamt/aui/mappings/DatabaseAtlQuery.java
@@ -72,7 +72,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 
 	/**
 	 * Get Probenahme their Analyseposition for an Messstelle
-	 * 
+	 *
 	 * @param probepunkt
 	 *            AtlProbpkt
 	 * @return <code>Map&lt;Probenahme,
@@ -114,7 +114,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 
 	/**
 	 * Liefert eine Liste der Analyseinstitute.
-	 * 
+	 *
 	 * @return String[]
 	 */
 	public static String[] getAnalysierer()
@@ -130,7 +130,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 	 * Get all <code>Analyseposition</code>s for a given
 	 * <code>Messstelle</code> and <code>Parameter</code> in a given
 	 * time interval
-	 * 
+	 *
 	 * @param param
 	 *            Parameter
 	 * @param pkt
@@ -160,7 +160,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 	/**
 	 * Get all <code>Analyseposition</code>s for a given
 	 * <code>Probenahme</code> and sort them
-	 * 
+	 *
 	 * @param probe
 	 *            Probenahme
 	 * @return List&lt;Analyseposition&gt;
@@ -180,7 +180,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 	 * Find an Analyseposition from a given Probenahme with the given
 	 * Parameter.
 	 * If there is none and createNew is true, create a new one.
-	 * 
+	 *
 	 * @param probe
 	 *            Probenahme
 	 * @param parameter
@@ -219,7 +219,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 
 	/**
 	 * Liefert alle in der Einheiten-Tabelle gespeicherten Einheiten.
-	 * 
+	 *
 	 * @return Ein Array mit allen Einheiten
 	 */
 	public static Einheiten[] getEinheiten()
@@ -235,7 +235,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 
 	/**
 	 * Get an unit by its description
-	 * 
+	 *
 	 * @param description
 	 *            The description of the unit (e.g. "mg/l")
 	 * @return <code>Einheiten</code>, if an unit was found,
@@ -253,7 +253,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 	/**
 	 * Check if an Einheiten with <code>description</code> exists.<br>
 	 * This is mainly used for the import.
-	 * 
+	 *
 	 * @param description
 	 *            String
 	 * @return <code>true</code>, if an Einheiten exists, <code>false</code>
@@ -279,7 +279,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 
 	/**
 	 * Liefert alle in der MapElkaAnalysemethode-Tabelle gespeicherten Analysemethode.
-	 * 
+	 *
 	 * @return Ein Array mit allen MapElkaAnalysemethode
 	 */
 	public static MapElkaAnalysemethode[] getMapElkaAnalysemethode()
@@ -302,7 +302,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 	/**
 	 * Get an array of all Klaeranlage,
 	 * omit id 7 because this is an intended duplicate
-	 * 
+	 *
 	 * @return Klaeranlage[]
 	 */
 	public static Klaeranlage[] getKlaeranlage()
@@ -326,7 +326,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 	/**
 	 * Liefert alle Parameter, die für Klärschlamm-Probenahme relevant sind.
 	 * D.h. alle, deren Klärschlamm-Grenzwert nicht <code>NULL</code> ist.
-	 * 
+	 *
 	 * @return Ein Array mit allen für Klärschlamm-Probenahme relevanten
 	 *         Parametern
 	 */
@@ -399,7 +399,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 
 	/**
 	 * Get a parameter by its description
-	 * 
+	 *
 	 * @param description
 	 *            The description of the parameter
 	 *            (e.g. "Palladium (Pd)")
@@ -419,7 +419,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 	/**
 	 * Check if an Parameter with <code>description</code> exists.<br>
 	 * This is mainly used for the import.
-	 * 
+	 *
 	 * @param description
 	 *            String
 	 * @return <code>true</code>, if an Parameter exists, <code>false</code>
@@ -482,7 +482,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 
 	/**
 	 * Liefert alle vorhandenen Probearten.
-	 * 
+	 *
 	 * @return Alle vorhandenen Probearten
 	 */
 	public static Probeart[] getProbearten()
@@ -502,7 +502,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 
 	/**
 	 * Liefert alle Probenahme eines bestimmten Probepunktes.
-	 * 
+	 *
 	 * @param punkt
 	 *            Der Probepunkt.
 	 * @return List&lt;Probenahme&gt;
@@ -519,7 +519,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 
 	/**
 	 * Liefert eine bestimmte Probenahme.
-	 * 
+	 *
 	 * @param kennummer
 	 *            Die Kennummer der Probenahme
 	 * @return Die Probe mit der gegebenen ID oder <code>null</code> falls diese
@@ -537,7 +537,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 	/**
 	 * Liefert alle Probenahme einer bestimmten Art von einer bestimmten
 	 * Kläranlage.
-	 * 
+	 *
 	 * @param art
 	 *            Probeart
 	 * @param ka
@@ -561,7 +561,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 	/**
 	 * Find Probenahme with <code>value</code> somewhere in
 	 * <code>propertyName</code> (search case insensitive).
-	 * 
+	 *
 	 * @param propertyName
 	 *            String
 	 * @param value
@@ -585,7 +585,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 
 	/**
 	 * Find Probenahme with <code>status</code>
-	 * 
+	 *
 	 * @param status
 	 *            Status
 	 * @return List&lt;Probenahme&gt;
@@ -602,7 +602,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 
 	/**
 	 * Check if there is an Probenahme with <code>kennnummer</code>
-	 * 
+	 *
 	 * @param kennnummer
 	 *            String
 	 * @return <code>true</code>, if an Probenahme exists,
@@ -822,7 +822,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 
 	/**
 	 * Get all Messstelle with Probeart(ID)
-	 * 
+	 *
 	 * @return <code>List&lt;Messstelle&gt;</code>
 	 */
 	public static List<Messstelle> getProbepktByArtID(Integer atlProbeartID)
@@ -841,7 +841,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 
 	/**
 	 * Get all inactive Messstelle
-	 * 
+	 *
 	 * @return <code>List&lt;Messstelle&gt;</code>
 	 */
 	public static List<Messstelle> getInaktivProbepkt()
@@ -858,7 +858,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 	/**
 	 * Get all Messstelle which have Probenahme from Probenehmer
 	 * (kennummer starts with "3").
-	 * 
+	 *
 	 * @return <code>List&lt;Messstelle&gt;</code>
 	 */
 	public static List<Messstelle> getProbenehmerPunkte()
@@ -880,7 +880,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 	/**
 	 * Get all Messstelle which have Probenahme from ESatzung
 	 * (kennummer starts with "E").
-	 * 
+	 *
 	 * @return <code>List&lt;Messstelle&gt;</code>
 	 */
 	public static List<Messstelle> getESatzungsPunkte()
@@ -900,7 +900,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 	/**
 	 * Get all Messstelle which have Probenahme from UWB
 	 * (kennummer starts with "2").
-	 * 
+	 *
 	 * @return <code>List&lt;Messstelle&gt;</code>
 	 */
 	public static List<Messstelle> getUWBPunkte()
@@ -920,7 +920,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 	/**
 	 * Get all Messstelle which have Probenahme from Selbstueberwachung
 	 * (kennummer starts with "7").
-	 * 
+	 *
 	 * @return <code>List&lt;Messstelle&gt;</code>
 	 */
 	public static List<Messstelle> getSelbstueberwPunkte()
@@ -939,7 +939,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 
 	/**
 	 * Get the one(!) Messstelle for the Klärschlamm
-	 * 
+	 *
 	 * @param art
 	 *            AtlProbe(punkt)art
 	 * @param ka
@@ -976,16 +976,16 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 
 	/**
 	 * Find Sielhaut starting with the <code>search</code> String
-	 * 
+	 *
 	 * @return <code>List&lt;Sielhaut&gt;</code>
 	 */
-	
-	
+
+
 	public static Object[] findSielhaut(String search)
 	{
 
 		boolean bSearch = (search != null && search.length() > 0);
-		
+
 		String query = "SELECT s.id, s.bezeichnung, s.lage, s.PSielhaut, s.PFirmenprobe, s.PNachprobe, o.inaktiv "
 				+ "FROM Sielhaut s, Messstelle m, Objekt o "
 				+ "WHERE s.messstelle = m AND m.objekt = o AND s.deleted = false ";
@@ -993,14 +993,40 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 					query += "AND s.bezeichnung like '" + search + "%' ";
 				}
 				query +=  "ORDER BY s.PSielhaut DESC, s.PFirmenprobe DESC, o.inaktiv ASC, s.bezeichnung ASC" ;
-		
-				
+
+
 		List sielhaut = HibernateSessionFactory.currentSession().createQuery(query).list();
-		
+
 		return (Object[]) sielhaut.toArray();
 	}
-	
-	
+
+
+	/**
+	 * Find Sielhaut starting with the <code>search</code> String
+	 *
+	 * @return <code>List&lt;Sielhaut&gt;</code>
+	 */
+
+
+	 public static Object[] findActiveSielhaut(String search) {
+
+		boolean bSearch = (search != null && search.length() > 0);
+
+		 String query = "SELECT s.id, s.bezeichnung, s.lage, s.PSielhaut, s.PFirmenprobe, s.PNachprobe, o.inaktiv "
+				+ "FROM Sielhaut s, Messstelle m, Objekt o "
+				+ "WHERE s.messstelle = m AND m.objekt = o AND s.deleted = false AND o.inaktiv = false";
+				if (bSearch) {
+					query += "AND s.bezeichnung like '" + search + "%' ";
+				}
+				query += " ORDER BY s.bezeichnung ASC, s.PSielhaut DESC, s.PFirmenprobe DESC, o.inaktiv ASC" ;
+
+
+		List sielhaut = HibernateSessionFactory.currentSession().createQuery(query).list();
+
+		return (Object[]) sielhaut.toArray();
+	}
+
+
 	/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 	/* Queries for package ATL : class Status */
 	/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -1009,7 +1035,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 
 	/**
 	 * Get all Status
-	 * 
+	 *
 	 * @return <code>Status[]</code>
 	 */
 	public static Status[] getStatus()
@@ -1025,7 +1051,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 
 	/**
 	 * Hole den nächsten Status - für den Wullspuffel ;-)
-	 * 
+	 *
 	 * @param aktuellerStatus
 	 * @return <code>Status</code> nächster Status
 	 */
@@ -1055,7 +1081,7 @@ abstract class DatabaseAtlQuery extends DatabaseBasisQuery
 	 * wurden. Wenn <code>analyseVon</code> nicht <code>null</code> oder "" ist,
 	 * werden nur Analysepositionen geliefert, die von einer bestimmten Stelle
 	 * analysiert wurden.
-	 * 
+	 *
 	 * @param param
 	 *            Der Parameter
 	 * @param einheit

--- a/src/de/bielefeld/umweltamt/aui/module/SielhautPrinter.java
+++ b/src/de/bielefeld/umweltamt/aui/module/SielhautPrinter.java
@@ -255,10 +255,17 @@ public class SielhautPrinter extends AbstractModul {
             if (!path.endsWith(fileSeparator)) {
                 pathBuilder.append(fileSeparator);
             }
-            pathBuilder
-                .append("Sielhautsteckbrief-")
-                .append(spunkt.getId())
-                .append(".pdf");
+            if (spunkt.getBezeichnung() != null && !spunkt.getBezeichnung().isEmpty()) {
+                pathBuilder
+                    .append(spunkt.getBezeichnung())
+                    .append(".pdf");
+            } else {
+                pathBuilder
+                    .append("Sielhautsteckbrief-")
+                    .append(spunkt.getId())
+                    .append(".pdf");
+            }
+
             try {
                 File export = new File(pathBuilder.toString());
                 PDFExporter.getInstance().exportReport(params, PDFExporter.SIELHAUT_BEARBEITEN,

--- a/src/de/bielefeld/umweltamt/aui/module/SielhautPrinter.java
+++ b/src/de/bielefeld/umweltamt/aui/module/SielhautPrinter.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright 2005-2011, Stadt Bielefeld
+ *
+ * This file is part of AUIK (Anlagen- und Indirekteinleiter-Kataster).
+ *
+ * AUIK is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * AUIK is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with AUIK. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * AUIK has been developed by Stadt Bielefeld and Intevation GmbH.
+ */
+package de.bielefeld.umweltamt.aui.module;
+
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+
+import javax.swing.AbstractButton;
+import javax.swing.JButton;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JToolBar;
+import javax.swing.table.TableColumn;
+
+import com.jgoodies.forms.builder.PanelBuilder;
+import com.jgoodies.forms.layout.CellConstraints;
+import com.jgoodies.forms.layout.FormLayout;
+
+import de.bielefeld.umweltamt.aui.AbstractModul;
+import de.bielefeld.umweltamt.aui.module.common.tablemodels.selectable.SelectableSielhautModel;
+import de.bielefeld.umweltamt.aui.utils.CheckBoxTableHeader;
+
+public class SielhautPrinter extends AbstractModul {
+
+    private JPanel contentPanel;
+    private JScrollPane tableScrollPane;
+
+    private JTable sielhautTable;
+    private SelectableSielhautModel sielhautModel;
+    private TableColumn checkBoxColumn;
+
+    private JToolBar toolbar;
+    private JButton printButton;
+
+    @Override
+    public String getName() {
+        return "Sielhautsteckbriefe drucken";
+    }
+
+    @Override
+    public String getCategory() {
+        return "Sielhaut";
+    }
+
+    @Override
+    public JPanel getPanel() {
+        return contentPanel;
+    }
+
+    @SuppressWarnings("deprecation")
+    public SielhautPrinter() {
+        //Create components
+        //Result table
+        this.sielhautTable = new JTable();
+        this.sielhautModel = new SelectableSielhautModel();
+        this.sielhautTable.setModel(this.sielhautModel);
+        this.tableScrollPane = new JScrollPane(this.sielhautTable,
+                JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+                JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        this.checkBoxColumn
+            = this.sielhautTable.getColumnModel().getColumn(0);
+        this.checkBoxColumn.setCellEditor(
+            this.sielhautTable.getDefaultEditor(Boolean.class));
+        this.checkBoxColumn.setCellRenderer(
+            this.sielhautTable.getDefaultRenderer(Boolean.class));
+        this.checkBoxColumn.setHeaderRenderer(
+            new CheckBoxTableHeader(new CheckBoxHeaderClickListener()));
+        this.checkBoxColumn.setMaxWidth(25);
+        this.checkBoxColumn.setResizable(false);
+        //Checkbox column click listener
+        this.sielhautTable.addMouseListener(new CheckboxColumnClickListener());
+
+        //Toolbar
+        this.printButton = new JButton("Drucken");
+        this.toolbar = new JToolBar();
+        this.toolbar.setFloatable(false);
+        this.toolbar.setRollover(true);
+        this.toolbar.add(this.printButton);
+
+        //Content panel
+        FormLayout layout = new FormLayout(
+            "3dlu, 180dlu:g, 3dlu, min(36dlu;p), 3dlu",
+            "3dlu, 400dlu:g, 3dlu, 20dlu,");
+        PanelBuilder builder = new PanelBuilder(layout);
+        CellConstraints cc = new CellConstraints();
+
+        builder.add(toolbar, cc.xy(4, 4));
+        builder.add(tableScrollPane, cc.xyw(2, 2, 3));
+        this.contentPanel = builder.build();
+
+        this.loadTableData();
+    }
+
+    private void loadTableData() {
+        this.sielhautModel.filterList("");
+    }
+
+    /**
+     * Listener handling clicks on the header checkbox
+     */
+    class CheckBoxHeaderClickListener implements ItemListener {
+        @Override
+        public void itemStateChanged(ItemEvent e) {
+            Object source = e.getSource();
+            if (source instanceof AbstractButton == false) {
+                return;
+            }
+            boolean checked = e.getStateChange() == ItemEvent.SELECTED;
+            for(int x = 0, y = sielhautTable.getRowCount(); x < y; x++) {
+                sielhautTable.setValueAt(Boolean.valueOf(checked),x,0);
+            }
+        }
+    }
+
+    /**
+     * Handler for clicks on the checkbox column
+     */
+    class CheckboxColumnClickListener implements MouseListener {
+
+        @Override
+        public void mouseClicked(MouseEvent evt) {
+            int row = sielhautTable.rowAtPoint(evt.getPoint());
+            int column = sielhautTable.columnAtPoint(evt.getPoint());
+            if (column == 0) {
+                Boolean curVal = (Boolean) sielhautTable.getValueAt(row, column);
+                sielhautTable.setValueAt(!curVal, row, column);
+            }
+        }
+
+        @Override
+        public void mouseEntered(MouseEvent arg0) {
+        }
+
+        @Override
+        public void mouseExited(MouseEvent arg0) {
+        }
+
+        @Override
+        public void mousePressed(MouseEvent arg0) {
+        }
+
+        @Override
+        public void mouseReleased(MouseEvent arg0) {
+        }
+    }
+}

--- a/src/de/bielefeld/umweltamt/aui/module/SielhautPrinter.java
+++ b/src/de/bielefeld/umweltamt/aui/module/SielhautPrinter.java
@@ -270,9 +270,9 @@ public class SielhautPrinter extends AbstractModul {
                 File export = new File(pathBuilder.toString());
                 PDFExporter.getInstance().exportReport(params, PDFExporter.SIELHAUT_BEARBEITEN,
                     export.getAbsolutePath(), false);
-                result.put(spunkt.getId().toString(), "erfolgreich erstellt");
+                result.put(spunkt.getBezeichnung().toString(), "erfolgreich erstellt");
             } catch (Exception ex) {
-                result.put(spunkt.getId().toString(), ex.getLocalizedMessage());
+                result.put(spunkt.getBezeichnung().toString(), ex.getLocalizedMessage());
             }
         }
         return result;
@@ -330,11 +330,11 @@ public class SielhautPrinter extends AbstractModul {
         resultBuilder.append(String.format("<b>Pfad:</b> %s <br>", path))
         .append("<ul>");
 
-        result.forEach((id, resultString) -> {
+        result.forEach((bezeichnung, resultString) -> {
             resultBuilder
                 .append("<li>")
                 .append(
-                    String.format("<b>Sielhautpunkt %s</b>: %s <br>", id, resultString))
+                    String.format("<b>Sielhautpunkt %s</b>: %s <br>", bezeichnung, resultString))
                 .append("</li>");
 
         });

--- a/src/de/bielefeld/umweltamt/aui/module/SielhautPrinter.java
+++ b/src/de/bielefeld/umweltamt/aui/module/SielhautPrinter.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.swing.AbstractButton;
-import javax.swing.Box;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JFileChooser;
@@ -45,7 +44,6 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextArea;
-import javax.swing.JToolBar;
 import javax.swing.table.TableColumn;
 
 import com.jgoodies.forms.builder.PanelBuilder;
@@ -56,7 +54,6 @@ import de.bielefeld.umweltamt.aui.AbstractModul;
 import de.bielefeld.umweltamt.aui.GUIManager;
 import de.bielefeld.umweltamt.aui.SettingsManager;
 import de.bielefeld.umweltamt.aui.mappings.atl.Sielhaut;
-import de.bielefeld.umweltamt.aui.module.common.tablemodels.SielhautModel;
 import de.bielefeld.umweltamt.aui.module.common.tablemodels.selectable.SelectableSielhautModel;
 import de.bielefeld.umweltamt.aui.utils.CheckBoxTableHeader;
 import de.bielefeld.umweltamt.aui.utils.PDFExporter;
@@ -70,7 +67,6 @@ public class SielhautPrinter extends AbstractModul {
     private SelectableSielhautModel sielhautModel;
     private TableColumn checkBoxColumn;
 
-    private JToolBar toolbar;
     private JButton printButton;
 
     private String outputPath = "./reports";
@@ -126,10 +122,6 @@ public class SielhautPrinter extends AbstractModul {
                 }
             }
         });
-        this.toolbar = new JToolBar();
-        this.toolbar.setFloatable(false);
-        this.toolbar.setRollover(true);
-        this.toolbar.add(this.printButton);
 
         //Content panel
         FormLayout layout = new FormLayout(
@@ -138,7 +130,7 @@ public class SielhautPrinter extends AbstractModul {
         PanelBuilder builder = new PanelBuilder(layout);
         CellConstraints cc = new CellConstraints();
 
-        builder.add(toolbar, cc.xy(4, 4));
+        builder.add(printButton, cc.xy(4, 4));
         builder.add(tableScrollPane, cc.xyw(2, 2, 3));
         this.contentPanel = builder.build();
 
@@ -173,8 +165,6 @@ public class SielhautPrinter extends AbstractModul {
             }
         });
 
-
-        JToolBar tb = new JToolBar();
         JButton cancelButton = new JButton("abbrechen");
         cancelButton.addActionListener(new java.awt.event.ActionListener() {
             @Override
@@ -211,22 +201,19 @@ public class SielhautPrinter extends AbstractModul {
                     String.format("%s Sielhautsteckbrief(e) erstellt", count.getText()));
             }
         });
-        tb.add(Box.createHorizontalGlue());
-        tb.add(okButton);
-        tb.addSeparator();
-        tb.add(cancelButton);
 
         FormLayout layout = new FormLayout(
-            "5dlu, 100dlu, 75dlu:g, 5dlu, 50dlu, 5dlu",
+            "5dlu, 100dlu, 75dlu:g, 25dlu, 5dlu, 25dlu, 3dlu, 25dlu, 5dlu",
             "5dlu, 35dlu, 35dlu, 3dlu:g, 35dlu, 5dlu");
         PanelBuilder builder = new PanelBuilder(layout);
         CellConstraints cc = new CellConstraints();
         builder.add(countLabel, cc.xy(2, 2));
-        builder.add(count, cc.xy(3, 2));
+        builder.add(count, cc.xyw(3, 2, 5));
         builder.add(pathLabel, cc.xy(2, 3));
-        builder.add(path, cc.xy(3, 3));
-        builder.add(pathButton, cc.xy(5, 3));
-        builder.add(tb, cc.xyw(2, 5, 4));
+        builder.add(path, cc.xyw(3, 3, 2));
+        builder.add(pathButton, cc.xyw(6, 3, 3));
+        builder.add(cancelButton, cc.xyw(4, 5, 3));
+        builder.add(okButton, cc.xy(8, 5));
 
         JPanel dialogContent = builder.build();
 

--- a/src/de/bielefeld/umweltamt/aui/module/common/tablemodels/selectable/SelectableSielhautModel.java
+++ b/src/de/bielefeld/umweltamt/aui/module/common/tablemodels/selectable/SelectableSielhautModel.java
@@ -20,10 +20,12 @@
  */
 package de.bielefeld.umweltamt.aui.module.common.tablemodels.selectable;
 
+import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.List;
 
 import de.bielefeld.umweltamt.aui.mappings.DatabaseQuery;
+import de.bielefeld.umweltamt.aui.mappings.atl.Sielhaut;
 import de.bielefeld.umweltamt.aui.utils.AuikLogger;
 import de.bielefeld.umweltamt.aui.utils.tablemodelbase.ListTableModel;
 
@@ -38,6 +40,8 @@ public class SelectableSielhautModel extends ListTableModel {
 
     /** Logging */
     private static final AuikLogger log = AuikLogger.getLogger();
+
+    private static final int ID_INDEX = 1;
 
     public SelectableSielhautModel () {
         super(new String[] {"", "Bezeichnung", "Lage", "R", "F", "N", "I"}, false);
@@ -105,6 +109,19 @@ public class SelectableSielhautModel extends ListTableModel {
 
     public int getSelectedCount() {
         return getSelected().length;
+    }
+
+    public Sielhaut getModelFromRow(Object[] row) {
+        Integer id = (Integer) row[ID_INDEX];
+        if (id == null) {
+            throw new InvalidParameterException("Keine Sielhautpunkt ID gefunden");
+        }
+        Sielhaut sielhaut = Sielhaut.findById(id);
+        if (sielhaut == null) {
+            throw new InvalidParameterException(
+                String.format("Sielhautpunkt %d nicht gefunden", id));
+        }
+        return sielhaut;
     }
 
     public Object[] getSelected() {

--- a/src/de/bielefeld/umweltamt/aui/module/common/tablemodels/selectable/SelectableSielhautModel.java
+++ b/src/de/bielefeld/umweltamt/aui/module/common/tablemodels/selectable/SelectableSielhautModel.java
@@ -103,6 +103,22 @@ public class SelectableSielhautModel extends ListTableModel {
         return tmp;
     }
 
+    public int getSelectedCount() {
+        return getSelected().length;
+    }
+
+    public Object[] getSelected() {
+        List<Object> result = new ArrayList<>();
+        List<Object[]> rows = (List<Object[]>) this.getList();
+        rows.forEach(row -> {
+            Boolean selected = (Boolean) row[0];
+            if (selected) {
+                result.add(row);
+            }
+        });
+        return result.toArray();
+    }
+
     @Override
     public Class<?> getColumnClass(int columnIndex) {
         if (columnIndex == 0 || columnIndex > 2) {

--- a/src/de/bielefeld/umweltamt/aui/module/common/tablemodels/selectable/SelectableSielhautModel.java
+++ b/src/de/bielefeld/umweltamt/aui/module/common/tablemodels/selectable/SelectableSielhautModel.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2005-2011, Stadt Bielefeld
+ *
+ * This file is part of AUIK (Anlagen- und Indirekteinleiter-Kataster).
+ *
+ * AUIK is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * AUIK is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with AUIK. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * AUIK has been developed by Stadt Bielefeld and Intevation GmbH.
+ */
+package de.bielefeld.umweltamt.aui.module.common.tablemodels.selectable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import de.bielefeld.umweltamt.aui.mappings.DatabaseQuery;
+import de.bielefeld.umweltamt.aui.utils.AuikLogger;
+import de.bielefeld.umweltamt.aui.utils.tablemodelbase.ListTableModel;
+
+/**
+ * Table model for Sielhaut objects adding a boolean to use for checkbox columns.
+ *
+ * @author Alexander Woestmann<awoestmann@intevation.de>
+ */
+public class SelectableSielhautModel extends ListTableModel {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Logging */
+    private static final AuikLogger log = AuikLogger.getLogger();
+
+    public SelectableSielhautModel () {
+        super(new String[] {"", "Bezeichnung", "Lage", "R", "F", "N", "I"}, false);
+    }
+
+    @Override
+    public void setValueAt(Object val, int row, int col) {
+        if (!rowExists(row) || col > this.getColumnCount()) {
+            return;
+        }
+        Object[] rowObj = (Object[]) getObjectAtRow(row);
+        rowObj[col] = val;
+        fireTableDataChanged();
+    }
+
+    @Override
+    public Object getColumnValue(Object objectAtRow, int columnIndex) {
+        Object[] obj = (Object[]) objectAtRow;
+        Object tmp;
+
+        switch (columnIndex) {
+            case 0:
+                tmp = obj[0];
+                break;
+            case 1:
+                tmp = obj[2];
+                break;
+            case 2:
+                tmp = obj[3];
+                break;
+            case 3:
+                if (obj[4] == null) {
+                    tmp = Boolean.valueOf(false);
+                } else {
+                    tmp = Boolean.valueOf((Boolean) obj[4]);
+                }
+                break;
+            case 4:
+                if (obj[5] == null) {
+                    tmp = Boolean.valueOf(false);
+                } else {
+                    tmp = Boolean.valueOf((Boolean) obj[5]);
+                }
+                break;
+            case 5:
+                if (obj[6] == null) {
+                    tmp = Boolean.valueOf(false);
+                } else {
+                    tmp = Boolean.valueOf((Boolean) obj[6]);
+                }
+                break;
+            case 6:
+                if (obj[7] == null) {
+                    tmp = Boolean.valueOf(false);
+                } else {
+                    tmp = Boolean.valueOf((Boolean) obj[7]);
+                }
+                break;
+            default:
+                tmp = "FEHLER!";
+                break;
+        }
+        return tmp;
+    }
+
+    @Override
+    public Class<?> getColumnClass(int columnIndex) {
+        if (columnIndex == 0 || columnIndex > 2) {
+            return Boolean.class;
+        } else {
+            return super.getColumnClass(columnIndex);
+        }
+    }
+
+    @Override
+    public void updateList() {
+    }
+
+    public void filterList(String suche) {
+        //Get Sielhaut objects
+        Object[] array = DatabaseQuery.findSielhaut(suche);
+        //Prepend selectable boolean
+        List<Object[]> list = new ArrayList();
+        for(Object rowObj: array) {
+            Object[] row = (Object[]) rowObj;
+            Object[] listEntry = new Object[row.length + 1];
+            listEntry[0] = Boolean.valueOf(false);
+            System.arraycopy(rowObj, 0, listEntry, 1, row.length - 1);
+            list.add(listEntry);
+        }
+        setList(list);
+        log.debug("Suche nach '" + suche + "' (" + getList().size()
+            + " Ergebnisse)");
+    }
+}

--- a/src/de/bielefeld/umweltamt/aui/module/common/tablemodels/selectable/SelectableSielhautModel.java
+++ b/src/de/bielefeld/umweltamt/aui/module/common/tablemodels/selectable/SelectableSielhautModel.java
@@ -151,7 +151,7 @@ public class SelectableSielhautModel extends ListTableModel {
 
     public void filterList(String suche) {
         //Get Sielhaut objects
-        Object[] array = DatabaseQuery.findSielhaut(suche);
+        Object[] array = DatabaseQuery.findActiveSielhaut(suche);
         //Prepend selectable boolean
         List<Object[]> list = new ArrayList();
         for(Object rowObj: array) {

--- a/src/de/bielefeld/umweltamt/aui/utils/CheckBoxTableHeader.java
+++ b/src/de/bielefeld/umweltamt/aui/utils/CheckBoxTableHeader.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2005-2011, Stadt Bielefeld
+ *
+ * This file is part of AUIK (Anlagen- und Indirekteinleiter-Kataster).
+ *
+ * AUIK is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * AUIK is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with AUIK. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * AUIK has been developed by Stadt Bielefeld and Intevation GmbH.
+ */
+package de.bielefeld.umweltamt.aui.utils;
+
+import java.awt.Component;
+import java.awt.event.MouseEvent;
+import java.awt.event.ItemListener;
+
+import javax.swing.JCheckBox;
+import javax.swing.JTable;
+import javax.swing.SwingConstants;
+import javax.swing.event.MouseInputListener;
+import javax.swing.table.JTableHeader;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableColumnModel;
+
+/**
+ * TableCellRender displaying a checkbox to use as "select all" button in table headers.
+ *
+ * @author Alexander Woestmann <awoestmann@intevation.de>
+ */
+public class CheckBoxTableHeader extends JCheckBox implements TableCellRenderer, MouseInputListener{
+
+    private static final long serialVersionUID = 1L;
+
+    protected CheckBoxTableHeader rendererComponent;
+    protected int column;
+    protected boolean mousePressed = true;
+
+    public CheckBoxTableHeader(ItemListener itemListener) {
+        rendererComponent = this;
+        rendererComponent.addItemListener(itemListener);
+        setHorizontalAlignment(SwingConstants.CENTER);
+      }
+
+    protected void handleClickEvent(MouseEvent e) {
+        if (mousePressed) {
+            mousePressed=false;
+            JTableHeader header = (JTableHeader)(e.getSource());
+            JTable tableView = header.getTable();
+            TableColumnModel columnModel = tableView.getColumnModel();
+            int viewColumn = columnModel.getColumnIndexAtX(e.getX());
+            int column = tableView.convertColumnIndexToModel(viewColumn);
+
+            if (viewColumn == this.column && e.getClickCount() == 1 && column != -1) {
+              doClick();
+            }
+          }
+    }
+
+    @Override
+    public Component getTableCellRendererComponent(JTable table, Object arg1, boolean arg2, boolean arg3, int arg4,
+            int arg5) {
+        if (table != null) {
+            JTableHeader header = table.getTableHeader();
+            if (header != null) {
+                rendererComponent.setForeground(header.getForeground());
+                rendererComponent.setBackground(header.getBackground());
+                rendererComponent.setFont(header.getFont());
+                header.addMouseListener(rendererComponent);
+            }
+        }
+        setColumn(column);
+        //setBorder(UIManager.getBorder("TableHeader.cellBorder"));
+        return rendererComponent;
+    }
+
+    protected void setColumn(int column) {
+        this.column = column;
+    }
+
+    public int getColumn() {
+        return column;
+    }
+
+    @Override
+    public void mouseClicked(MouseEvent e) {
+        handleClickEvent(e);
+        ((JTableHeader)e.getSource()).repaint();
+    }
+
+    @Override
+    public void mouseEntered(MouseEvent arg0) {
+    }
+
+    @Override
+    public void mouseExited(MouseEvent arg0) {
+    }
+
+    @Override
+    public void mousePressed(MouseEvent arg0) {
+        mousePressed = true;
+    }
+
+    @Override
+    public void mouseReleased(MouseEvent arg0) {
+    }
+
+    @Override
+    public void mouseDragged(MouseEvent arg0) {
+    }
+
+    @Override
+    public void mouseMoved(MouseEvent arg0) {
+    }
+}

--- a/src/de/bielefeld/umweltamt/aui/utils/PDFExporter.java
+++ b/src/de/bielefeld/umweltamt/aui/utils/PDFExporter.java
@@ -109,7 +109,7 @@ public class PDFExporter {
 
 	/**
 	 * Methode liefert den Vorlagenpfad für die Jasper-Vorlagen
-	 * 
+	 *
 	 * @return
 	 */
 	private String getPathToJasper() {
@@ -143,8 +143,8 @@ public class PDFExporter {
 				// TODO Auto-generated catch block
 				e.printStackTrace();
 			}
-		} 
-		
+		}
+
 		inputStream = AUIKataster.class.getResourceAsStream(path);
 		return inputStream;
 	}
@@ -176,17 +176,43 @@ public class PDFExporter {
 	 *            Der Pfad zu einem Ort an dem das PDF gespeichert werden soll.
 	 * @param connection
 	 *            SQL connection fuer den Report
-	 *
+	 * @param show True wenn die erzeugte Datei engezeigt werden soll
 	 * @return ein bef&uuml;lltes {@link JasperPrint} Objekt.
 	 */
 	protected static JasperPrint export(Map<String, Object> fields,
 			InputStream reportFile, String dest, Connection connection)
 			throws JRException {
+		return export(fields, reportFile, dest, connection, true);
+	}
+
+	/**
+	 * Diese Funktion erzeugt ein PDF mit Hilfe von <i>JasperReport</i>. Die
+	 * dazu ben&ouml;tigten Templates m&uuml;ssen sich in <i>build/reports/</i>
+	 * befinden und bereits compiliert sein.
+	 *
+	 * @param fields
+	 *            Ein Map Objekt dessen Werte in das Template einzuf&uuml;llen
+	 *            sind.
+	 * @param reportFile
+	 *            Der Name des <i>JasperReport</i> Templates <b>ohne</b> Endung.
+	 * @param dest
+	 *            Der Pfad zu einem Ort an dem das PDF gespeichert werden soll.
+	 * @param connection
+	 *            SQL connection fuer den Report
+	 * @param show True wenn die erzeugte Datei engezeigt werden soll
+	 * @return ein bef&uuml;lltes {@link JasperPrint} Objekt.
+	 */
+	protected static JasperPrint export(Map<String, Object> fields,
+			InputStream reportFile, String dest, Connection connection,
+			boolean show)
+			throws JRException {
 		JasperPrint print = JasperFillManager.fillReport(reportFile, fields,
 				connection);
         //dest = "/home/awoestmann/test.pdf";
 		JasperExportManager.exportReportToPdfFile(print, dest);
-		AuikUtils.spawnFileProg(new File(dest));
+		if (show) {
+			AuikUtils.spawnFileProg(new File(dest));
+		}
 
 		return print;
 	}
@@ -319,13 +345,36 @@ public class PDFExporter {
 	 *            Der Name des Jasper Report templates.
 	 * @param destination
 	 *            Der Pfad zu einem Ort, an dem das PDF gespeichert werden soll.
+	 * @return ein bef&uuml;lltes {@link JasperPrint} Objekt.
+	 */
+	public JasperPrint exportReport(Map<String, Object> fields, String report,
+	String destination) throws Exception {
+		return exportReport(fields, report, destination, true);
+	}
+
+	/**
+	 * Diese Funktion erzeugt ein PDF aus einer Jasper Report Vorlage. Der
+	 * eigentliche Export wird von {@link export(Map, String, String)}
+	 * get&auml;tigt. Das verwendete Template hei&szilg;t wird als parameter
+	 * <i>report</i> &uuml;bergeben und muss sich in <i>build/reports</i> in
+	 * compilierter Form befinden. Als Datenquelle wird die jdbc verbindung
+	 * verwendet.
 	 *
+	 * @param fields
+	 *            Ein Map Objekt dessen Werte in das Template einzuf&uuml;llen
+	 *            sind.
+	 * @param report
+	 *            Der Name des Jasper Report templates.
+	 * @param destination
+	 *            Der Pfad zu einem Ort, an dem das PDF gespeichert werden soll.
+	 * @param show True wenn die erzeugte Datei angezeigt werden soll
 	 * @return ein bef&uuml;lltes {@link JasperPrint} Objekt.
 	 */
 	@SuppressWarnings("deprecation")
 	// See comment below for hibernate4
 	public JasperPrint exportReport(Map<String, Object> fields, String report,
-			String destination) throws Exception {
+			String destination, boolean show) throws Exception {
+
 		InputStream inputStream = getResourceAsStream(report);
 
 		if (inputStream == null) {
@@ -337,18 +386,18 @@ public class PDFExporter {
 			JasperPrint jprint = null;
 			//Deprecated
 			//Connection con = HibernateSessionFactory.currentSession()
-			//		.connection(); 
+			//		.connection();
 			//jprint = export(fields, inputStream, destination, con);
-			
+
 			// With Hibernate 4:
 			HibernateSessionFactory.currentSession().doWork( new Work() {
 			public void execute(Connection con) throws SQLException {
 			//jprint = export(fields, inputStream, destination, connection); }
 			connection = con;}
 			} );
-			 
-			jprint = export(fields, inputStream, destination, connection);
-			
+
+			jprint = export(fields, inputStream, destination, connection, show);
+
 			return jprint;
 		} catch (JRException jre) {
 			jre.printStackTrace();


### PR DESCRIPTION
Hiermit sollte #144 gelöst sein:

* Fügt ein Modul hinzu in dem alle Sielhautpunkte in einer Tabelle angezeigt werden (Modul "Sielhautsteckbriefe erstellen", Kategorie "Sielhaut")
* Die Tabelle enthält eine Checkbox-Spalte für die Auswahl so wie eine Checkbox in der Kopfzeile um alles auszuwählen
* Nach einen Klick auf "Drucken" öffnet sich ein Fenster in dem ein Pfad ausgewählt und das Erstellen der Steckbriefe gestartet werden kann. Der Standardpfad wird aus der auik.properties gelesen (Property: `auik.system.spath_steckbriefe`).
* Nach dem Erstellen der Steckbriefe wird nochmal ein Ergebnisfenster angezeigt in dem für jeden Steckbrief aufgelistet wird ob das Erstellen erfolgreich war. 

Notwendige Config Änderungen:

* `auik.system.module=[...],SielhautPrinter,[...]`
* `auik.system.spath_steckbriefe=X:\Standard\Export\Pfad`