### PR TITLE
Changes QGis data fetch

### DIFF
--- a/src/de/bielefeld/umweltamt/aui/module/SielhautBearbeiten.java
+++ b/src/de/bielefeld/umweltamt/aui/module/SielhautBearbeiten.java
@@ -1893,7 +1893,15 @@ public class SielhautBearbeiten extends ObjectModule {
 					spE32Feld.setText(e32AusZeile.substring(0, 7));
 					spN32Feld.setText(n32AusZeile.substring(0, 7));
 					this.frame.changeStatus("Rechts- und Hochwert eingetragen", HauptFrame.SUCCESS_COLOR);
-				} else {
+				} else 
+					if (tmp.length == 2) {
+						String e32AusZeile = tmp[0];
+						String n32AusZeile = tmp[1];
+						spE32Feld.setText(e32AusZeile.substring(0, 7));
+						spN32Feld.setText(n32AusZeile.substring(0, 7));
+						this.frame.changeStatus("Rechts- und Hochwert eingetragen", HauptFrame.SUCCESS_COLOR);
+				}else
+				{
 					this.frame.changeStatus("Zwischenablage enthält keine verwertbaren Daten", HauptFrame.ERROR_COLOR);
 				}
 				break;


### PR DESCRIPTION
Bei uns soll von Qgis 3.1 auf QGis 3.22 upgedatet werden. Hier gibt es allerdings das AdOn was bisher die Rechts und Hochwerte geliefert hat so genau nicht mehr. Beim alten wurden die Rechts und Hochwerte in vier Spalten (also zwei verschieden Geodatensystemen) in die Zwischenablage gespeichert.  Davon wurde aber nur eine gebraucht. 
Jetzt kann man die Systeme einzeln kopieren und somit liefert die Zwischenablage nur noch zwei Spalten. Habe das jetzt mal angepasst aber die alte Variante noch drin gelassen. 

Hätte gerne deine eure Meinung dazu. :)

(Mein erster Pullrequest, ich hoffe das ist so richtig?) :)