### PR TITLE
Fix hausnrzus handling in findAdressen query

### DIFF
--- a/src/de/bielefeld/umweltamt/aui/mappings/DatabaseBasisQuery.java
+++ b/src/de/bielefeld/umweltamt/aui/mappings/DatabaseBasisQuery.java
@@ -390,7 +390,9 @@ abstract class DatabaseBasisQuery extends DatabaseIndeinlQuery {
 		query += "adresse.hausnr = " + hausnr + " AND ";
 		if (!zusatz.equals("")) {
 			query += "adresse.hausnrzus = '" + zusatz + "' AND ";
-		}		
+		} else {
+			query += "adresse.hausnrzus is null AND ";
+		}
 		query += "adresse.plz = '" + plz + "' AND ";
 		query += "adresse.deleted = false ";
 	


### PR DESCRIPTION
Hiermit sollten bei der Betreibererstellung auch Adressen korrekt zugeordnet werden die keinen Hausnummerzusatz haben.