### PR TITLE
Verbesserungen Import Panel

### DIFF
--- a/src/de/bielefeld/umweltamt/aui/module/Import.java
+++ b/src/de/bielefeld/umweltamt/aui/module/Import.java
@@ -20,6 +20,8 @@
  */
 package de.bielefeld.umweltamt.aui.module;
 
+import java.awt.Color;
+import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -34,6 +36,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
+import javax.swing.table.TableCellRenderer;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.factories.Paddings;
@@ -116,6 +119,7 @@ public class Import extends AbstractModul {
                     setImportStep(ImportStep.CHOOSE_FILE);
                     importer.reset();
                     parseFile(file);
+                    Import.this.table.clearSelection();
                 }
             }
         });
@@ -152,7 +156,17 @@ public class Import extends AbstractModul {
      * @return New table
      */
     private JTable createImportTable(AbstractImporter importer) {
-        JTable table = new JTable(importer);
+        JTable table = new JTable(importer) {
+            public Component prepareRenderer(TableCellRenderer renderer, int row, int column) {
+                Component c = super.prepareRenderer(renderer, row, column);
+                if (isRowSelected(row)) {
+                    c.setBackground(new Color(153, 204, 255, 100));
+                } else {
+                    c.setBackground(new Color(0, 0, 0, 0));
+                }
+                return c;
+            }
+        };
         table.getSelectionModel().addListSelectionListener(
             new ListSelectionListener() {
 

--- a/src/de/bielefeld/umweltamt/aui/module/Import.java
+++ b/src/de/bielefeld/umweltamt/aui/module/Import.java
@@ -160,7 +160,7 @@ public class Import extends AbstractModul {
             public Component prepareRenderer(TableCellRenderer renderer, int row, int column) {
                 Component c = super.prepareRenderer(renderer, row, column);
                 if (isRowSelected(row)) {
-                    c.setBackground(new Color(153, 204, 255, 100));
+                    c.setBackground(new Color(228, 244, 253));
                 } else {
                     c.setBackground(new Color(0, 0, 0, 0));
                 }

--- a/src/de/bielefeld/umweltamt/aui/module/importer/AbstractImporter.java
+++ b/src/de/bielefeld/umweltamt/aui/module/importer/AbstractImporter.java
@@ -35,6 +35,10 @@ public abstract class AbstractImporter extends ListTableModel {
 
     private static final long serialVersionUID = 1L;
 
+    protected static final String COLOR_RED = "FF1027";
+    protected static final String COLOR_ORANGE = "ff6600";
+    protected static final String COLOR_GREEN = "009900";
+
     /**
      * File to import.
      */

--- a/src/de/bielefeld/umweltamt/aui/module/importer/AbwasserImporter.java
+++ b/src/de/bielefeld/umweltamt/aui/module/importer/AbwasserImporter.java
@@ -137,19 +137,25 @@ public class AbwasserImporter extends AbstractImporter {
 
         switch (status) {
             case -1:
-                sb.append("<font color='red'>");
-                sb.append(txt);
-                sb.append("</font>");
+            sb.append("<font color='")
+            .append(COLOR_RED)
+            .append("'>")
+            .append(txt)
+            .append("</font>");
                 break;
             case 1:
-                sb.append("<font color='green'>");
-                sb.append(txt);
-                sb.append("</font>");
+            sb.append("<font color='")
+            .append(COLOR_GREEN)
+            .append("'>")
+            .append(txt)
+            .append("</font>");
                 break;
             case 2:
-                sb.append("<font color='FF8200'>");
-                sb.append(txt);
-                sb.append("</font>");
+                sb.append("<font color='")
+                .append(COLOR_ORANGE)
+                .append("'>")
+                .append(txt)
+                .append("</font>");
                 break;
             default:
                 sb.append(txt);
@@ -162,13 +168,13 @@ public class AbwasserImporter extends AbstractImporter {
     public String getDescriptionString() {
         return
             "<html><table width='100%'>"
-            + "<tr><td style='color: green;'>Grün:</td>"
+            + "<tr><td style='color: " + COLOR_GREEN + ";'>Grün:</td>"
             + "<td>Import m&ouml;glich: Kennnummer und Parameter "
             + "vorhanden.</td></tr>"
-            + "<tr><td style='color: FF8200;'>Orange:</td>"
+            + "<tr><td style='color: " + COLOR_ORANGE + ";'>Orange:</td>"
             + "<td>Import m&ouml;glich: Kennnummer vorhanden, "
             + "Parameter wird angelegt.</td></tr>"
-            + "<tr><td style='color: red;'>Rot:</td>"
+            + "<tr><td style='color: " + COLOR_RED + ";'>Rot:</td>"
             + "<td>Zeile nicht importierbar.</td></tr>" + "</table></html>";
     }
 

--- a/src/de/bielefeld/umweltamt/aui/module/importer/AbwasserImporter.java
+++ b/src/de/bielefeld/umweltamt/aui/module/importer/AbwasserImporter.java
@@ -231,6 +231,14 @@ public class AbwasserImporter extends AbstractImporter {
         return null;
     }
 
+    @Override
+    public Class<?> getColumnClass(int columnIndex) {
+        switch(columnIndex) {
+            case 7: return Boolean.class;
+            default: return String.class;
+        }
+    }
+
     public List<String[]> getSelectedRows() {
         List<String[]> selected = new ArrayList<String[]>();
         int[] selectedRowIndices = this.parentTable.getSelectedRows();

--- a/src/de/bielefeld/umweltamt/aui/module/importer/SielhautImporter.java
+++ b/src/de/bielefeld/umweltamt/aui/module/importer/SielhautImporter.java
@@ -94,34 +94,34 @@ public class SielhautImporter extends AbstractImporter {
     @Override
     public Object getColumnValue(Object objectAtRow, int columnIndex) {
         String[] tmpArr = (String[]) objectAtRow;
-        Object value;
+        StringBuilder builder = new StringBuilder();
+        String tmp = "";
+        builder.append("<html><font color=");
+        if (isPositionImportable(tmpArr)) {
+            builder.append(COLOR_GREEN);
+        } else {
+            builder.append(COLOR_RED);
+        }
+        builder.append(">");
         switch (columnIndex) {
             case 0:
-                String tmp;
-                tmp = "<html><font color=";
-                if (isPositionImportable(tmpArr)) {
-                    tmp += COLOR_GREEN;
-                } else {
-                    tmp += COLOR_RED;
-                }
-                String nr = getIdNumberFromLine(tmpArr);
-                value = tmp + ">" + nr + "</font> ";
+                tmp = getIdNumberFromLine(tmpArr);
                 break;
             case 1:
-                value = getParamFromLine(tmpArr);
+                tmp = getParamFromLine(tmpArr);
                 break;
             case 2:
-                value = getValueFromLine(tmpArr);
+                tmp = getValueFromLine(tmpArr);
                 break;
             case 3:
-                value = getUnitFromLine(tmpArr);
+                tmp = getUnitFromLine(tmpArr);
                 break;
-
             default:
-                value = null;
-                break;
+                return null;
         }
-        return value;
+        builder.append(tmp)
+            .append("</font></html>");
+        return (Object) builder.toString();
     }
 
     @Override

--- a/src/de/bielefeld/umweltamt/aui/module/importer/SielhautImporter.java
+++ b/src/de/bielefeld/umweltamt/aui/module/importer/SielhautImporter.java
@@ -100,9 +100,9 @@ public class SielhautImporter extends AbstractImporter {
                 String tmp;
                 tmp = "<html><font color=";
                 if (isPositionImportable(tmpArr)) {
-                    tmp += "00cc00";
+                    tmp += COLOR_GREEN;
                 } else {
-                    tmp += "red";
+                    tmp += COLOR_RED;
                 }
                 String nr = getIdNumberFromLine(tmpArr);
                 value = tmp + ">" + nr + "</font> ";
@@ -275,8 +275,8 @@ public class SielhautImporter extends AbstractImporter {
     public String getDescriptionString() {
         return
             "<html>"
-            + "<font color=green>Grün:</font> Position kann problemlos importiert werden.<br>"
-            + "<font color=red>Rot:</font> Probenahme nicht gefunden oder Parameter/Einheit unbekannt."
+            + "<font color=" + COLOR_GREEN + ">Grün:</font> Position kann problemlos importiert werden.<br>"
+            + "<font color=" + COLOR_RED + ">Rot:</font> Probenahme nicht gefunden oder Parameter/Einheit unbekannt."
             + "</html>";
     }
 


### PR DESCRIPTION
Hier sollte #156 gelöst sein:

* Nach dem Laden einer Datei sollten keine Zeilen mehr ausgewählt sein
* Die Farbe ausgewählter Zeilen wurde festgelegt um die Lesbarkeit zu verbessern
* Die Farbkodierung der Zeilen ist jetzt mithilfe von Konstanten in `AbstractImporter.java` festgelegt um eine einheitliche Farbkodierung sicherzustellen.

Um die Farben der Zeilen anzupassen können die  folgenden Konstanten im AbstractImporter angepasst werden:
```java
    protected static final String COLOR_RED = "...";
    protected static final String COLOR_ORANGE = "...";
    protected static final String COLOR_GREEN = "...";
```
Damit sollten sowohl die Zeilen als auch die Beschreibungstexte entsprechend angepasst werden.